### PR TITLE
Update README.md to include input listener 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ manifest:
     path: config
 ```
 
-Then, edit your `build.yml` to look like this:
+Then, edit your `build.yml` to look like this, 3.5 is now on main:
 
 ```yml
 on: [workflow_dispatch]
 
 jobs:
   build:
-    uses: petejohanson/zmk/.github/workflows/build-user-config.yml@core/zephyr-3.5-update
+    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main
 ```
 
 Now, update your `board.overlay` adding the necessary bits (update the pins for your board accordingly):
@@ -79,6 +79,14 @@ Now, update your `board.overlay` adding the necessary bits (update the pins for 
         // scroll-layers = <2 3>;
         // automouse-layer = <4>;
     };
+};
+
+/ {
+  trackball_listener {
+    compatible = "zmk,input-listener";
+    device = <&trackball>;
+
+  };
 };
 ```
 


### PR DESCRIPTION
https://discord.com/channels/719497620560543766/845285481888743434/1209077420905205790

> Updated input subsystem usage in PR #2027, which specifically will address ensuring that concurrent input events from different devices won't be processed out of order or interleaved. Now, any device needs an explicit "input listener" config, which is now also where all the "input configs" used to live. 

Added the listener to the guide. As well as swapped over to main as 3.5 is now in main.