### PR TITLE
rough implementation of "require-prior-idle-ms" for automouse layer

### DIFF
--- a/dts/bindings/pixart,pmw3610.yml
+++ b/dts/bindings/pixart,pmw3610.yml
@@ -10,11 +10,11 @@ properties:
     type: phandle-array
     required: true
   scroll-layers:
-    type: array
-    default: []
+    type: int
+    default: -1
   snipe-layers:
-    type: array
-    default: []
+    type: int
+    default: -1
   automouse-layer:
     type: int
     default: -1

--- a/dts/bindings/pixart,pmw3610.yml
+++ b/dts/bindings/pixart,pmw3610.yml
@@ -10,11 +10,11 @@ properties:
     type: phandle-array
     required: true
   scroll-layers:
-    type: int
-    default: -3
+    type: array
+    default: []
   snipe-layers:
-    type: int
-    default: -2
+    type: array
+    default: []
   automouse-layer:
     type: int
     default: -1

--- a/dts/bindings/pixart,pmw3610.yml
+++ b/dts/bindings/pixart,pmw3610.yml
@@ -10,11 +10,11 @@ properties:
     type: phandle-array
     required: true
   scroll-layers:
-    type: array
-    default: []
+    type: int
+    default: -3
   snipe-layers:
-    type: array
-    default: []
+    type: int
+    default: -2
   automouse-layer:
     type: int
     default: -1

--- a/dts/bindings/pixart,pmw3610.yml
+++ b/dts/bindings/pixart,pmw3610.yml
@@ -18,3 +18,6 @@ properties:
   automouse-layer:
     type: int
     default: -1
+  require-prior-idle-ms:
+    type: int
+    default: -1

--- a/dts/bindings/pixart,pmw3610.yml
+++ b/dts/bindings/pixart,pmw3610.yml
@@ -10,11 +10,11 @@ properties:
     type: phandle-array
     required: true
   scroll-layers:
-    type: int
-    default: -1
+    type: array
+    default: []
   snipe-layers:
-    type: int
-    default: -1
+    type: array
+    default: []
   automouse-layer:
     type: int
     default: -1

--- a/src/pixart.h
+++ b/src/pixart.h
@@ -55,10 +55,6 @@ struct pixart_config {
     struct gpio_dt_spec irq_gpio;
     struct spi_dt_spec bus;
     struct gpio_dt_spec cs_gpio;
-    size_t scroll_layers_len;
-    int32_t *scroll_layers;
-    size_t snipe_layers_len;
-    int32_t *snipe_layers;
 };
 
 #ifdef __cplusplus

--- a/src/pixart.h
+++ b/src/pixart.h
@@ -59,6 +59,7 @@ struct pixart_config {
     int32_t *scroll_layers;
     size_t snipe_layers_len;
     int32_t *snipe_layers;
+    int32_t require_prior_idle_ms;
 };
 
 #ifdef __cplusplus

--- a/src/pixart.h
+++ b/src/pixart.h
@@ -26,8 +26,11 @@ struct pixart_data {
     int32_t scroll_delta_x;
     int32_t scroll_delta_y;
 
-#ifdef CONFIG_PMW3610_POLLING_RATE_125_SW
+#ifdef CONFIG_PMW3610_POLLING_RATE_125_SW || (DT_PROP(DT_DRV_INST(0), automouse_layer) > 1 && DT_PROP(DT_DRV_INST(0), require_prior_idle_ms) > 0)
     int64_t last_poll_time;
+#endif
+
+#ifdef CONFIG_PMW3610_POLLING_RATE_125_SW
     int16_t last_x;
     int16_t last_y;
 #endif

--- a/src/pixart.h
+++ b/src/pixart.h
@@ -55,6 +55,10 @@ struct pixart_config {
     struct gpio_dt_spec irq_gpio;
     struct spi_dt_spec bus;
     struct gpio_dt_spec cs_gpio;
+    size_t scroll_layers_len;
+    int32_t *scroll_layers;
+    size_t snipe_layers_len;
+    int32_t *snipe_layers;
 };
 
 #ifdef __cplusplus

--- a/src/pixart.h
+++ b/src/pixart.h
@@ -26,7 +26,7 @@ struct pixart_data {
     int32_t scroll_delta_x;
     int32_t scroll_delta_y;
 
-#if defined(CONFIG_PMW3610_POLLING_RATE_125_SW) || (DT_PROP(DT_DRV_INST(0), automouse_layer) > 1 && DT_PROP(DT_DRV_INST(0), require_prior_idle_ms) > 0)
+#if defined(CONFIG_PMW3610_POLLING_RATE_125_SW) || (DT_PROP(DT_DRV_INST(0), automouse_layer) > 0 && DT_PROP(DT_DRV_INST(0), require_prior_idle_ms) > 0)
     int64_t last_poll_time;
 #endif
 

--- a/src/pixart.h
+++ b/src/pixart.h
@@ -26,7 +26,7 @@ struct pixart_data {
     int32_t scroll_delta_x;
     int32_t scroll_delta_y;
 
-#ifdef CONFIG_PMW3610_POLLING_RATE_125_SW || (DT_PROP(DT_DRV_INST(0), automouse_layer) > 1 && DT_PROP(DT_DRV_INST(0), require_prior_idle_ms) > 0)
+#if defined(CONFIG_PMW3610_POLLING_RATE_125_SW) || (DT_PROP(DT_DRV_INST(0), automouse_layer) > 1 && DT_PROP(DT_DRV_INST(0), require_prior_idle_ms) > 0)
     int64_t last_poll_time;
 #endif
 

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -559,7 +559,7 @@ static void store_last_tapped(int64_t timestamp) {
     }
 }
 
-static bool is_quick_tap(const struct pixart_config *config, int64_t timestamp) {
+static bool is_quick_tap(struct pixart_config *config, int64_t timestamp) {
     return (last_tapped_timestamp + config->require_prior_idle_ms) > timestamp;
 }
 

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -545,7 +545,7 @@ static void pmw3610_async_init(struct k_work *work) {
 
 #define AUTOMOUSE_LAYER (DT_PROP(DT_DRV_INST(0), automouse_layer))
 #if AUTOMOUSE_LAYER > 0
-#define IDLE_MS config->require_prior_idle_ms
+#define IDLE_MS DT_PROP(DT_DRV_INST(0), require_prior_idle_ms)
 struct k_timer automouse_layer_timer;
 static bool automouse_triggered = false;
 
@@ -707,7 +707,7 @@ static int pmw3610_report_data(const struct device *dev) {
     }
 #endif
 
-#ifdef CONFIG_PMW3610_POLLING_RATE_125_SW || (AUTOMOUSE_LAYER > 0 && IDLE_MS > 0)
+#if defined(CONFIG_PMW3610_POLLING_RATE_125_SW) || (AUTOMOUSE_LAYER > 0 && IDLE_MS > 0)
     int64_t curr_time = k_uptime_get();
     if (data->last_poll_time == 0 || curr_time - data->last_poll_time > 128) {
         data->last_poll_time = curr_time;

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -549,7 +549,7 @@ static bool automouse_triggered = false;
 
 static void activate_automouse_layer() {
     automouse_triggered = true;
-    zmk_keymap_layer_activate(AUTOMOUSE_LAYER, false);
+    zmk_keymap_layer_activate(AUTOMOUSE_LAYER);
     k_timer_start(&automouse_layer_timer, K_MSEC(CONFIG_PMW3610_AUTOMOUSE_TIMEOUT_MS), K_NO_WAIT);
 }
 

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -610,7 +610,7 @@ static int pmw3610_report_data(const struct device *dev) {
     data->curr_mode = input_mode;
 
 #if AUTOMOUSE_LAYER > 0
-    if (input_mode == MOVE &&
+    if (input_mode == MOVE && zmk_keymap_highest_layer_active() == SNIPE_LAYER && zmk_keymap_highest_layer_active() != SCROLL_LAYER &&
             (automouse_triggered || zmk_keymap_highest_layer_active() != AUTOMOUSE_LAYER)
     ) {
         activate_automouse_layer();

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -579,7 +579,6 @@ int behavior_move_listener(const zmk_event_t *eh) {
 }
 
 ZMK_LISTENER(pmw3610, behavior_move_listener);
-ZMK_SUBSCRIPTION(pmw3610, zmk_position_state_changed);
 ZMK_SUBSCRIPTION(pmw3610, zmk_keycode_state_changed);
 
 static void activate_automouse_layer() {

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -559,7 +559,7 @@ static void store_last_tapped(int64_t timestamp) {
     }
 }
 
-static bool is_quick_tap(pixart_config *config, int64_t timestamp) {
+static bool is_quick_tap(const struct pixart_config *config, int64_t timestamp) {
     return (last_tapped_timestamp + config->require_prior_idle_ms) > timestamp;
 }
 

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -563,19 +563,15 @@ static void deactivate_automouse_layer(struct k_timer *timer) {
 K_TIMER_DEFINE(automouse_layer_timer, deactivate_automouse_layer, NULL);
 #endif
 
-static enum pixart_input_mode get_input_mode_for_current_layer(const struct device *dev) {
-    const struct pixart_config *config = dev->config;
+static enum pixart_input_mode get_input_mode_for_current_layer() {
     uint8_t curr_layer = zmk_keymap_highest_layer_active();
-    for (size_t i = 0; i < config->scroll_layers_len; i++) {
-        if (curr_layer == config->scroll_layers[i]) {
+    if (curr_layer == SCROLL_LAYER) {
             return SCROLL;
         }
-    }
-    for (size_t i = 0; i < config->snipe_layers_len; i++) {
-        if (curr_layer == config->snipe_layers[i]) {
+    if (curr_layer == SNIPE_LAYER) {
             return SNIPE;
         }
-    }
+
     return MOVE;
 }
 
@@ -589,7 +585,7 @@ static int pmw3610_report_data(const struct device *dev) {
     }
 
     int32_t dividor;
-    enum pixart_input_mode input_mode = get_input_mode_for_current_layer(dev);
+    enum pixart_input_mode input_mode = get_input_mode_for_current_layer();
     bool input_mode_changed = data->curr_mode != input_mode;
     switch (input_mode) {
     case MOVE:
@@ -814,9 +810,7 @@ static int pmw3610_init(const struct device *dev) {
 }
 
 #define PMW3610_DEFINE(n)                                                                          \
-    static struct pixart_data data##n;                                                             \
-    static int32_t scroll_layers##n[] = DT_PROP(DT_DRV_INST(n), scroll_layers);                    \
-    static int32_t snipe_layers##n[] = DT_PROP(DT_DRV_INST(n), snipe_layers);                      \
+    static struct pixart_data data##n;                                                             \                     \
     static const struct pixart_config config##n = {                                                \
         .irq_gpio = GPIO_DT_SPEC_INST_GET(n, irq_gpios),                                           \
         .bus =                                                                                     \
@@ -830,11 +824,7 @@ static int pmw3610_init(const struct device *dev) {
                         .slave = DT_INST_REG_ADDR(n),                                              \
                     },                                                                             \
             },                                                                                     \
-        .cs_gpio = SPI_CS_GPIOS_DT_SPEC_GET(DT_DRV_INST(n)),                                       \
-        .scroll_layers = scroll_layers##n,                                                         \
-        .scroll_layers_len = DT_PROP_LEN(DT_DRV_INST(n), scroll_layers),                           \
-        .snipe_layers = snipe_layers##n,                                                           \
-        .snipe_layers_len = DT_PROP_LEN(DT_DRV_INST(n), snipe_layers),                             \
+        .cs_gpio = SPI_CS_GPIOS_DT_SPEC_GET(DT_DRV_INST(n)),                                       \                          \
     };                                                                                             \
                                                                                                    \
     DEVICE_DT_INST_DEFINE(n, pmw3610_init, NULL, &data##n, &config##n, POST_KERNEL,                \

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -610,7 +610,7 @@ static int pmw3610_report_data(const struct device *dev) {
     data->curr_mode = input_mode;
 
 #if AUTOMOUSE_LAYER > 0
-    if (input_mode == MOVE && zmk_keymap_highest_layer_active() == SNIPE_LAYER && zmk_keymap_highest_layer_active() != SCROLL_LAYER &&
+    if (input_mode == MOVE && zmk_keymap_highest_layer_active() != SNIPE_LAYER && zmk_keymap_highest_layer_active() != SCROLL_LAYER &&
             (automouse_triggered || zmk_keymap_highest_layer_active() != AUTOMOUSE_LAYER)
     ) {
         activate_automouse_layer();

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -613,7 +613,7 @@ static int pmw3610_report_data(const struct device *dev) {
     data->curr_mode = input_mode;
 
 #if AUTOMOUSE_LAYER > 0
-    if (input_mode == MOVE &&
+    if (input_mode == MOVE && zmk_keymap_highest_layer_active() != config->snipe_layers[0] && zmk_keymap_highest_layer_active() != config->scroll_layers[0]
             (automouse_triggered || zmk_keymap_highest_layer_active() != AUTOMOUSE_LAYER)
     ) {
         activate_automouse_layer();

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -854,7 +854,6 @@ static int pmw3610_init(const struct device *dev) {
     static int32_t snipe_layers##n[] = DT_PROP(DT_DRV_INST(n), snipe_layers);                      \
     static const struct pixart_config config##n = {                                                \
         .irq_gpio = GPIO_DT_SPEC_INST_GET(n, irq_gpios),                                           \
-        .require_prior_idle_ms = DT_PROP(n, require_prior_idle_ms),                                \
         .bus =                                                                                     \
             {                                                                                      \
                 .bus = DEVICE_DT_GET(DT_INST_BUS(n)),                                              \
@@ -871,6 +870,7 @@ static int pmw3610_init(const struct device *dev) {
         .scroll_layers_len = DT_PROP_LEN(DT_DRV_INST(n), scroll_layers),                           \
         .snipe_layers = snipe_layers##n,                                                           \
         .snipe_layers_len = DT_PROP_LEN(DT_DRV_INST(n), snipe_layers),                             \
+        .require_prior_idle_ms = DT_PROP(n, require_prior_idle_ms),                                \
     };                                                                                             \
                                                                                                    \
     DEVICE_DT_INST_DEFINE(n, pmw3610_init, NULL, &data##n, &config##n, POST_KERNEL,                \

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -648,8 +648,8 @@ static int pmw3610_report_data(const struct device *dev) {
     data->curr_mode = input_mode;
 
 #if AUTOMOUSE_LAYER > 0
-    if (input_mode == MOVE && !is_quick_tap(config, data->last_poll_time) &&
-            (automouse_triggered || zmk_keymap_highest_layer_active() != AUTOMOUSE_LAYER)
+    if (input_mode == MOVE &&
+            (automouse_triggered || (zmk_keymap_highest_layer_active() != AUTOMOUSE_LAYER && !is_quick_tap(config, data->last_poll_time)))
     ) {
         activate_automouse_layer();
     }

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -648,7 +648,7 @@ static int pmw3610_report_data(const struct device *dev) {
     data->curr_mode = input_mode;
 
 #if AUTOMOUSE_LAYER > 0
-    if (input_mode == MOVE && !is_quick_tap(config, data->last_poll_time)
+    if (input_mode == MOVE && !is_quick_tap(config, data->last_poll_time) &&
             (automouse_triggered || zmk_keymap_highest_layer_active() != AUTOMOUSE_LAYER)
     ) {
         activate_automouse_layer();

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -543,8 +543,6 @@ static void pmw3610_async_init(struct k_work *work) {
 }
 
 #define AUTOMOUSE_LAYER (DT_PROP(DT_DRV_INST(0), automouse_layer))
-#define SCROLL_LAYER (DT_PROP(DT_DRV_INST(0), scroll_layers))
-#define SNIPE_LAYER (DT_PROP(DT_DRV_INST(0), snipe_layers))
 #if AUTOMOUSE_LAYER > 0
 struct k_timer automouse_layer_timer;
 static bool automouse_triggered = false;
@@ -563,15 +561,20 @@ static void deactivate_automouse_layer(struct k_timer *timer) {
 K_TIMER_DEFINE(automouse_layer_timer, deactivate_automouse_layer, NULL);
 #endif
 
-static enum pixart_input_mode get_input_mode_for_current_layer() {
+static enum pixart_input_mode get_input_mode_for_current_layer(const struct device *dev) {
+    const struct pixart_config *config = dev->config;
     uint8_t curr_layer = zmk_keymap_highest_layer_active();
-    if (curr_layer ==SCROLL_LAYER) {
-        return SCROLL;
+    for (size_t i = 0; i < config->scroll_layers_len; i++) {
+        if (curr_layer == config->scroll_layers[i]) {
+            return SCROLL;
+        }
     }
-    if (curr_layer == SNIPE_LAYER) {
-        return SNIPE;
+    for (size_t i = 0; i < config->snipe_layers_len; i++) {
+        if (curr_layer == config->snipe_layers[i]) {
+            return SNIPE;
+        }
     }
-return MOVE;
+    return MOVE;
 }
 
 static int pmw3610_report_data(const struct device *dev) {
@@ -584,7 +587,7 @@ static int pmw3610_report_data(const struct device *dev) {
     }
 
     int32_t dividor;
-    enum pixart_input_mode input_mode = get_input_mode_for_current_layer();
+    enum pixart_input_mode input_mode = get_input_mode_for_current_layer(dev);
     bool input_mode_changed = data->curr_mode != input_mode;
     switch (input_mode) {
     case MOVE:
@@ -610,7 +613,7 @@ static int pmw3610_report_data(const struct device *dev) {
     data->curr_mode = input_mode;
 
 #if AUTOMOUSE_LAYER > 0
-    if (input_mode == MOVE && zmk_keymap_highest_layer_active() != SNIPE_LAYER && zmk_keymap_highest_layer_active() != SCROLL_LAYER &&
+    if (input_mode == MOVE &&
             (automouse_triggered || zmk_keymap_highest_layer_active() != AUTOMOUSE_LAYER)
     ) {
         activate_automouse_layer();
@@ -810,6 +813,8 @@ static int pmw3610_init(const struct device *dev) {
 
 #define PMW3610_DEFINE(n)                                                                          \
     static struct pixart_data data##n;                                                             \
+    static int32_t scroll_layers##n[] = DT_PROP(DT_DRV_INST(n), scroll_layers);                    \
+    static int32_t snipe_layers##n[] = DT_PROP(DT_DRV_INST(n), snipe_layers);                      \
     static const struct pixart_config config##n = {                                                \
         .irq_gpio = GPIO_DT_SPEC_INST_GET(n, irq_gpios),                                           \
         .bus =                                                                                     \
@@ -824,6 +829,10 @@ static int pmw3610_init(const struct device *dev) {
                     },                                                                             \
             },                                                                                     \
         .cs_gpio = SPI_CS_GPIOS_DT_SPEC_GET(DT_DRV_INST(n)),                                       \
+        .scroll_layers = scroll_layers##n,                                                         \
+        .scroll_layers_len = DT_PROP_LEN(DT_DRV_INST(n), scroll_layers),                           \
+        .snipe_layers = snipe_layers##n,                                                           \
+        .snipe_layers_len = DT_PROP_LEN(DT_DRV_INST(n), snipe_layers),                             \
     };                                                                                             \
                                                                                                    \
     DEVICE_DT_INST_DEFINE(n, pmw3610_init, NULL, &data##n, &config##n, POST_KERNEL,                \

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -549,7 +549,7 @@ static bool automouse_triggered = false;
 
 static void activate_automouse_layer() {
     automouse_triggered = true;
-    zmk_keymap_layer_activate(AUTOMOUSE_LAYER);
+    zmk_keymap_layer_activate(AUTOMOUSE_LAYER, false);
     k_timer_start(&automouse_layer_timer, K_MSEC(CONFIG_PMW3610_AUTOMOUSE_TIMEOUT_MS), K_NO_WAIT);
 }
 

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -549,7 +549,7 @@ struct k_timer automouse_layer_timer;
 static bool automouse_triggered = false;
 
 // this keeps track of the last non-cmove, non-mod key tap
-int64_t last_tapped_timestamp = INT32_MIN;
+extern int64_t last_tapped_timestamp;
 // this keeps track of the last time a move was pressed
 int64_t last_move_timestamp = INT32_MIN;
 

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -651,7 +651,7 @@ static int pmw3610_report_data(const struct device *dev) {
     data->curr_mode = input_mode;
 
 #if AUTOMOUSE_LAYER > 0
-    if (input_mode == MOVE && !is_quick_tap(config, timestamp)
+    if (input_mode == MOVE && !is_quick_tap(config, data->last_poll_time)
             (automouse_triggered || zmk_keymap_highest_layer_active() != AUTOMOUSE_LAYER)
     ) {
         activate_automouse_layer();
@@ -728,7 +728,7 @@ static int pmw3610_report_data(const struct device *dev) {
 
     if (x != 0 || y != 0) {
         if (input_mode != SCROLL) {
-            last_move_timestamp = timestamp;
+            last_move_timestamp = data->last_poll_time;
             input_report_rel(dev, INPUT_REL_X, x, false, K_FOREVER);
             input_report_rel(dev, INPUT_REL_Y, y, true, K_FOREVER);
         } else {

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -543,6 +543,8 @@ static void pmw3610_async_init(struct k_work *work) {
 }
 
 #define AUTOMOUSE_LAYER (DT_PROP(DT_DRV_INST(0), automouse_layer))
+#define SCROLL_LAYER (DT_PROP(DT_DRV_INST(0), scroll_layers))
+#define SNIPE_LAYER (DT_PROP(DT_DRV_INST(0), snipe_layers))
 #if AUTOMOUSE_LAYER > 0
 struct k_timer automouse_layer_timer;
 static bool automouse_triggered = false;
@@ -613,7 +615,7 @@ static int pmw3610_report_data(const struct device *dev) {
     data->curr_mode = input_mode;
 
 #if AUTOMOUSE_LAYER > 0
-    if (input_mode == MOVE && zmk_keymap_highest_layer_active() != config->snipe_layers[0] && zmk_keymap_highest_layer_active() != config->scroll_layers[0]
+    if (input_mode == MOVE && zmk_keymap_highest_layer_active() != SNIPE_LAYER && zmk_keymap_highest_layer_active() != SCROLL_LAYER
             (automouse_triggered || zmk_keymap_highest_layer_active() != AUTOMOUSE_LAYER)
     ) {
         activate_automouse_layer();

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -559,7 +559,7 @@ static void store_last_tapped(int64_t timestamp) {
     }
 }
 
-static bool is_quick_tap(struct pixart_config *config, int64_t timestamp) {
+static bool is_quick_tap(const struct pixart_config *config, int64_t timestamp) {
     return (last_tapped_timestamp + config->require_prior_idle_ms) > timestamp;
 }
 

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -543,6 +543,8 @@ static void pmw3610_async_init(struct k_work *work) {
 }
 
 #define AUTOMOUSE_LAYER (DT_PROP(DT_DRV_INST(0), automouse_layer))
+#define SCROLL_LAYER (DT_PROP(DT_DRV_INST(0), scroll_layers))
+#define SNIPE_LAYER (DT_PROP(DT_DRV_INST(0), snipe_layers))
 #if AUTOMOUSE_LAYER > 0
 struct k_timer automouse_layer_timer;
 static bool automouse_triggered = false;
@@ -561,20 +563,15 @@ static void deactivate_automouse_layer(struct k_timer *timer) {
 K_TIMER_DEFINE(automouse_layer_timer, deactivate_automouse_layer, NULL);
 #endif
 
-static enum pixart_input_mode get_input_mode_for_current_layer(const struct device *dev) {
-    const struct pixart_config *config = dev->config;
+static enum pixart_input_mode get_input_mode_for_current_layer() {
     uint8_t curr_layer = zmk_keymap_highest_layer_active();
-    for (size_t i = 0; i < config->scroll_layers_len; i++) {
-        if (curr_layer == config->scroll_layers[i]) {
-            return SCROLL;
-        }
+    if (curr_layer ==SCROLL_LAYER) {
+        return SCROLL;
     }
-    for (size_t i = 0; i < config->snipe_layers_len; i++) {
-        if (curr_layer == config->snipe_layers[i]) {
-            return SNIPE;
-        }
+    if (curr_layer == SNIPE_LAYER) {
+        return SNIPE;
     }
-    return MOVE;
+return MOVE;
 }
 
 static int pmw3610_report_data(const struct device *dev) {
@@ -587,7 +584,7 @@ static int pmw3610_report_data(const struct device *dev) {
     }
 
     int32_t dividor;
-    enum pixart_input_mode input_mode = get_input_mode_for_current_layer(dev);
+    enum pixart_input_mode input_mode = get_input_mode_for_current_layer();
     bool input_mode_changed = data->curr_mode != input_mode;
     switch (input_mode) {
     case MOVE:
@@ -813,8 +810,6 @@ static int pmw3610_init(const struct device *dev) {
 
 #define PMW3610_DEFINE(n)                                                                          \
     static struct pixart_data data##n;                                                             \
-    static int32_t scroll_layers##n[] = DT_PROP(DT_DRV_INST(n), scroll_layers);                    \
-    static int32_t snipe_layers##n[] = DT_PROP(DT_DRV_INST(n), snipe_layers);                      \
     static const struct pixart_config config##n = {                                                \
         .irq_gpio = GPIO_DT_SPEC_INST_GET(n, irq_gpios),                                           \
         .bus =                                                                                     \
@@ -829,10 +824,6 @@ static int pmw3610_init(const struct device *dev) {
                     },                                                                             \
             },                                                                                     \
         .cs_gpio = SPI_CS_GPIOS_DT_SPEC_GET(DT_DRV_INST(n)),                                       \
-        .scroll_layers = scroll_layers##n,                                                         \
-        .scroll_layers_len = DT_PROP_LEN(DT_DRV_INST(n), scroll_layers),                           \
-        .snipe_layers = snipe_layers##n,                                                           \
-        .snipe_layers_len = DT_PROP_LEN(DT_DRV_INST(n), snipe_layers),                             \
     };                                                                                             \
                                                                                                    \
     DEVICE_DT_INST_DEFINE(n, pmw3610_init, NULL, &data##n, &config##n, POST_KERNEL,                \

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -870,7 +870,7 @@ static int pmw3610_init(const struct device *dev) {
         .scroll_layers_len = DT_PROP_LEN(DT_DRV_INST(n), scroll_layers),                           \
         .snipe_layers = snipe_layers##n,                                                           \
         .snipe_layers_len = DT_PROP_LEN(DT_DRV_INST(n), snipe_layers),                             \
-        .require_prior_idle_ms = DT_PROP(n, require_prior_idle_ms),                                \
+        .require_prior_idle_ms = DT_PROP(DT_DRV_INST(0), require_prior_idle_ms),                                \
     };                                                                                             \
                                                                                                    \
     DEVICE_DT_INST_DEFINE(n, pmw3610_init, NULL, &data##n, &config##n, POST_KERNEL,                \

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -572,9 +572,7 @@ static int keycode_state_changed_listener(const zmk_event_t *eh) {
 }
 
 int behavior_move_listener(const zmk_event_t *eh) {
-    if (as_zmk_position_state_changed(eh) != NULL) {
-        return position_state_changed_listener(eh);
-    } else if (as_zmk_keycode_state_changed(eh) != NULL) {
+    if (as_zmk_keycode_state_changed(eh) != NULL) {
         return keycode_state_changed_listener(eh);
     }
     return ZMK_EV_EVENT_BUBBLE;


### PR DESCRIPTION
implemented require-prior-idle-ms based off of the one in combo. 
may have some issues with data->last_poll_time since that's only enabled for CONFIG_PMW3610_POLLING_RATE_125_SW=y