### PR TITLE
Add maccel to driver

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -42,6 +42,57 @@ config PMW3610_SNIPE_CPI
     help
       Snipe CPI value, with 200 step
 
+config PMW3610_MACCEL
+    bool "Enabled maccel"
+    default n
+    help
+      Enables drive level mouse acceleration based on burkfers and Wimads keyboard mouse acceleration equation.
+      Make sure to disable OS level mouse acceleration when using it
+
+config PMW3610_MACCEL_TAKEOFF
+    int "Mouse acceleration curve takes off more smoothly/abruptly, it will be divided by 100"
+    default 200
+    help
+        The TAKEOFF variable controls how smoothly or abruptly the acceleration curve takes off.
+        A higher value will make it take off more abruptly, a lower value smoothens out the start of the curve.
+
+config PMW3610_MACCEL_GROWTH_RATE
+    int "Mouse acceleration curve reaches its upper limit slower/faster, it will be divided by 100"
+    default 025
+    help
+        The GROWTH_RATE variable sets the growth rate of the acceleration curve.
+        A lower value will result in a flatter curve which takes longer to reach its LIMIT.
+        A higher value will result in a steeper curve, which will reach its LIMIT faster.
+
+config PMW3610_MACCEL_OFFSET
+    int "Mouse acceleration acceleration kicks in earlier/later, it will be divided by 100"
+    default 220
+    help
+        The OFFSET variable moves the entire curve towards the right. Offsetting the curve to the right 
+        means acceleration will kick in later, which is useful for low speed precision - in effect what 
+        you would otherwise have used SNIPING mode for. The maccel feature basically eliminates the 
+        need for a sniping mode.
+
+config PMW3610_MACCEL_LIMIT
+    int "Mouse acceleration lower limit of accel curve (minimum acceleration factor)"
+    default 020
+    help
+        The LIMIT variable sets the lower limit for the acceleration curve.
+        This is the minimum acceleration factor at which the curve will start.
+        In effect this adjusts the sensitivity for low speed precision movements.
+
+config PMW3610_MACCEL_LIMIT_UPPER
+    int "Mouse acceleration upper limit of accel curve (maximum acceleration factor), it will be divided by 100"
+    default 100
+    help
+        The upper limit of the curve is fixed at 1, which means that at high speed sensitivity equals your default DPI. If you want to adjust high speed sensitivity, adjust your DPI.
+
+config PMW3610_MACCEL_ROUNDING_CARRY_TIMEOUT_MS
+    int "Mouse acceleration reset error correction"
+    default 200
+    help
+        Milliseconds after which to reset quantization error correction (forget rounding remainder)
+
 config PMW3610_SNIPE_CPI_DIVIDOR
     int "PMW3610's CPI dividor in snipe mode"
     default 1

--- a/README.md
+++ b/README.md
@@ -113,8 +113,12 @@ All the parameters for the maccel equation can be changed(e.g. GROWTH_RATE,TAKE_
 affect the acceleration read [original documentation](https://github.com/finrod09/qmk_userspace_features/blob/main/maccel/readme.md#configuration). To change the parameters for maccell, you should multiply the value you intend to use by 100, as in the following example.
 
 ```conf
-CONFIG_PMW3610_MACCEL_TAKEOFF=200 //2.0
-CONFIG_PMW3610_MACCEL_GROWTH_RATE=025 //0.25
-CONFIG_PMW3610_MACCEL_OFFSET=220 //2.2
-CONFIG_PMW3610_MACCEL_LIMIT=020 //0.2
+# 200 instead of 2.0 for qmk
+CONFIG_PMW3610_MACCEL_TAKEOFF=200
+# 025 instead of 0.25 for qmk
+CONFIG_PMW3610_MACCEL_GROWTH_RATE=025
+# 220 instead of 2.2 for qmk
+CONFIG_PMW3610_MACCEL_OFFSET=220
+# 020 instead of 0.2 for qmk
+CONFIG_PMW3610_MACCEL_LIMIT=020
 ```

--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ To enable it, first make sure to disable OS level mouse acceleration and then ad
 
 ```conf
 CONFIG_PMW3610_MACCEL=y
+CONFIG_PMW3610_CPI_DIVIDOR=1
 ```
+
 All the parameters for the maccel equation can be changed(e.g. GROWTH_RATE,TAKE_OFF), to learn more about how these values 
 affect the acceleration read [original documentation](https://github.com/finrod09/qmk_userspace_features/blob/main/maccel/readme.md#configuration). To change the parameters for maccell, you should multiply the value you intend to use by 100, as in the following example.
 

--- a/README.md
+++ b/README.md
@@ -98,3 +98,21 @@ CONFIG_INPUT=y
 CONFIG_ZMK_MOUSE=y
 CONFIG_PMW3610=y
 ```
+
+
+## Mouse Acceleration
+This module also provides driver level mouse acceleration ported from [QMK maccel, developed by Wimads and finrod09](https://github.com/finrod09/qmk_userspace_features/tree/main/maccel). 
+To enable it, first make sure to disable OS level mouse acceleration and then add this to your `board.config`.
+
+```conf
+CONFIG_PMW3610_MACCEL=y
+```
+All the parameters for the maccel equation can be changed(e.g. GROWTH_RATE,TAKE_OFF), to learn more about how these values 
+affect the acceleration read [original documentation](https://github.com/finrod09/qmk_userspace_features/blob/main/maccel/readme.md#configuration). To change the parameters for maccell, you should multiply the value you intend to use by 100, as in the following example.
+
+```conf
+CONFIG_PMW3610_MACCEL_TAKEOFF=200 //2.0
+CONFIG_PMW3610_MACCEL_GROWTH_RATE=025 //0.25
+CONFIG_PMW3610_MACCEL_OFFSET=220 //2.2
+CONFIG_PMW3610_MACCEL_LIMIT=020 //0.2
+```

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -60,17 +60,19 @@ static int (*const async_init_fn[ASYNC_INIT_STEP_COUNT])(const struct device *de
     [ASYNC_INIT_STEP_CONFIGURE] = pmw3610_async_init_configure,
 };
 
+
+#ifdef CONFIG_PMW3610_MACCEL
 static int64_t maccel_timer;
 static maccel_config_t g_maccel_config = {
     // clang-format off
-    .growth_rate =  MACCEL_GROWTH_RATE,
-    .offset =       MACCEL_OFFSET,
-    .limit =        MACCEL_LIMIT,
-    .takeoff =      MACCEL_TAKEOFF,
+    .growth_rate =  CONFIG_PMW3610_MACCEL_GROWTH_RATE / 100.0f,
+    .offset =       CONFIG_PMW3610_MACCEL_OFFSET / 100.0f,
+    .limit =        CONFIG_PMW3610_MACCEL_LIMIT / 100.0f,
+    .takeoff =      CONFIG_PMW3610_MACCEL_TAKEOFF / 100.0f,
     .enabled =      true
     // clang-format on
 };
-
+#endif
 
 #define XY_REPORT_MIN INT8_MIN
 #define XY_REPORT_MAX INT8_MAX
@@ -709,16 +711,18 @@ static int pmw3610_report_data(const struct device *dev) {
         if (input_mode != SCROLL) {
 
 
+
+#ifdef CONFIG_PMW3610_MACCEL
             static float rounding_carry_x = 0;
             static float rounding_carry_y = 0;
 
             const int64_t delta_time = k_uptime_delta(&maccel_timer);
-            if (delta_time > MACCEL_ROUNDING_CARRY_TIMEOUT_MS) {
+            if (delta_time > CONFIG_PMW3610_MACCEL_ROUNDING_CARRY_TIMEOUT_MS) {
                 rounding_carry_x = 0;
                 rounding_carry_y = 0;
             }
             maccel_timer = k_uptime_get();
-            static uint16_t device_cpi = CONFIG_PMW3610_CPI;
+            uint32_t device_cpi = data->curr_cpi;
             const float dpi_correction = (float)1000.0f / device_cpi;
             // calculate euclidean distance moved (sqrt(x^2 + y^2))
             const float distance = sqrtf(x * x + y * y);
@@ -733,7 +737,8 @@ static int pmw3610_report_data(const struct device *dev) {
             const float m = g_maccel_config.limit;
             // acceleration factor: f(v) = 1 - (1 - M) / {1 + e^[K(v - S)]}^(G/K):
             // Generalised Sigmoid Function, see https://www.desmos.com/calculator/k9vr0y2gev
-            const float maccel_factor = MACCEL_LIMIT_UPPER - (MACCEL_LIMIT_UPPER - m) / powf(1 + expf(k * (velocity - s)), g / k);
+            const float upper_limit = CONFIG_PMW3610_MACCEL_LIMIT_UPPER / 100.0f;
+            const float maccel_factor = upper_limit - (upper_limit - m) / powf(1 + expf(k * (velocity - s)), g / k);
             // multiply mouse reports by acceleration factor, and account for previous quantization errors:
             const float new_x = rounding_carry_x + maccel_factor * x;
             const float new_y = rounding_carry_y + maccel_factor * y;
@@ -743,7 +748,7 @@ static int pmw3610_report_data(const struct device *dev) {
             // Clamp values and report back accelerated values.
             x = CONSTRAIN_REPORT(new_x);
             y = CONSTRAIN_REPORT(new_y);
-
+#endif
             input_report_rel(dev, INPUT_REL_X, x, false, K_FOREVER);
             input_report_rel(dev, INPUT_REL_Y, y, true, K_FOREVER);
         } else {

--- a/src/pmw3610.h
+++ b/src/pmw3610.h
@@ -7,30 +7,7 @@
 extern "C" {
 #endif
 
-
-
-#ifndef MACCEL_TAKEOFF
-#    define MACCEL_TAKEOFF 2.0 // lower/higher value = curve starts more smoothly/abruptly
-#endif
-#ifndef MACCEL_GROWTH_RATE
-#    define MACCEL_GROWTH_RATE 0.25 // lower/higher value = curve reaches its upper limit slower/faster
-#endif
-#ifndef MACCEL_OFFSET
-#    define MACCEL_OFFSET 2.2 // lower/higher value = acceleration kicks in earlier/later
-#endif
-#ifndef MACCEL_LIMIT
-#    define MACCEL_LIMIT 0.2 // lower limit of accel curve (minimum acceleration factor)
-#endif
-#ifndef MACCEL_CPI_THROTTLE_MS
-#    define MACCEL_CPI_THROTTLE_MS 200 // milliseconds to wait between requesting the device's current DPI
-#endif
-#ifndef MACCEL_LIMIT_UPPER
-#    define MACCEL_LIMIT_UPPER 1 // upper limit of accel curve, recommended to leave at 1; adjust DPI setting instead.
-#endif
-#ifndef MACCEL_ROUNDING_CARRY_TIMEOUT_MS
-#    define MACCEL_ROUNDING_CARRY_TIMEOUT_MS 200 // milliseconds after which to reset quantization error correction (forget rounding remainder)
-#endif
-
+#ifdef CONFIG_PMW3610_MACCEL
 typedef struct _maccel_config_t {
     float growth_rate;
     float offset;
@@ -38,7 +15,7 @@ typedef struct _maccel_config_t {
     float takeoff;
     bool  enabled;
 } maccel_config_t;
-
+#endif
 
 /* Timings (in us) used in SPI communication. Since MCU should not do other tasks during wait,
  * k_busy_wait is used instead of k_sleep */

--- a/src/pmw3610.h
+++ b/src/pmw3610.h
@@ -42,6 +42,9 @@ extern "C" {
 #endif
 
 #define MACCEL_MAGNIFICATION_DPI 1000
+#ifndef MACCEL_ROUNDING_CARRY_TIMEOUT_MS
+#    define MACCEL_ROUNDING_CARRY_TIMEOUT_MS 200 // milliseconds after which to reset quantization error correction (forget rounding remainder)
+#endif
 
 typedef struct _maccel_config_t {
     float scaling;

--- a/src/pmw3610.h
+++ b/src/pmw3610.h
@@ -26,13 +26,13 @@ extern "C" {
 #    define MACCEL_TAKEOFF     6.8     // (K) --/++ value --> curve starts smoothlier/abruptlier
 #endif
 #ifndef MACCEL_GROWTH_RATE
-#    define MACCEL_GROWTH_RATE 0.6     // (M) --/++ value --> max limit reached slower/faster
+#    define MACCEL_GROWTH_RATE 0.4     // (M) --/++ value --> max limit reached slower/faster
 #endif
 #ifndef MACCEL_OFFSET
 #    define MACCEL_OFFSET      1.0     // (S) --/++ value --> growth kicks in earlier/later
 #endif
 #ifndef MACCEL_LIMIT
-#    define MACCEL_LIMIT       9.6     // (M) maximum acceleration factor
+#    define MACCEL_LIMIT       8.6     // (M) maximum acceleration factor
 #endif
 #ifndef MACCEL_CPI_THROTTLE_MS
 #    define MACCEL_CPI_THROTTLE_MS 200 // milliseconds to wait between requesting the device's current DPI

--- a/src/pmw3610.h
+++ b/src/pmw3610.h
@@ -8,52 +8,38 @@ extern "C" {
 #endif
 
 
-#ifndef MACCEL_CPI
-#    ifdef POINTING_DEVICE_DRIVER_pmw3360
-#        define MACCEL_CPI 120.0
-#    elif POINTING_DEVICE_DRIVER_cirque_pinnacle_spi
-#        define MACCEL_CPI 120.0
-#    else
-#        warning "Unsupported pointing device driver! Please manually set the scaling parameter MACCEL_CPI to achieve a consistent acceleration curve!"
-#        define MACCEL_CPI 120.0
-#    endif
-#endif
-#ifdef MACCEL_SCALE
-#  error "You must rename MACCEL_SCALE as MACCEL_CPI in your `config.h`!"
-#endif // MACCEL_SCALE
+
 #ifndef MACCEL_TAKEOFF
-// https://www.desmos.com/calculator/vtfkbxwj8s
-#    define MACCEL_TAKEOFF     6.8     // (K) --/++ value --> curve starts smoothlier/abruptlier
+#    define MACCEL_TAKEOFF 2.0 // lower/higher value = curve starts more smoothly/abruptly
 #endif
 #ifndef MACCEL_GROWTH_RATE
-#    define MACCEL_GROWTH_RATE 0.4     // (M) --/++ value --> max limit reached slower/faster
+#    define MACCEL_GROWTH_RATE 0.25 // lower/higher value = curve reaches its upper limit slower/faster
 #endif
 #ifndef MACCEL_OFFSET
-#    define MACCEL_OFFSET      1.0     // (S) --/++ value --> growth kicks in earlier/later
+#    define MACCEL_OFFSET 2.2 // lower/higher value = acceleration kicks in earlier/later
 #endif
 #ifndef MACCEL_LIMIT
-#    define MACCEL_LIMIT       8.6     // (M) maximum acceleration factor
+#    define MACCEL_LIMIT 0.2 // lower limit of accel curve (minimum acceleration factor)
 #endif
 #ifndef MACCEL_CPI_THROTTLE_MS
 #    define MACCEL_CPI_THROTTLE_MS 200 // milliseconds to wait between requesting the device's current DPI
 #endif
-#ifndef MACCEL_ROUNDING_CURRY_TIMEOUT_MS
-#    define MACCEL_ROUNDING_CURRY_TIMEOUT_MS 300 // mouse report delta time after which quantization carry gets reset
+#ifndef MACCEL_LIMIT_UPPER
+#    define MACCEL_LIMIT_UPPER 1 // upper limit of accel curve, recommended to leave at 1; adjust DPI setting instead.
 #endif
-
-#define MACCEL_MAGNIFICATION_DPI 1000
 #ifndef MACCEL_ROUNDING_CARRY_TIMEOUT_MS
 #    define MACCEL_ROUNDING_CARRY_TIMEOUT_MS 200 // milliseconds after which to reset quantization error correction (forget rounding remainder)
 #endif
 
 typedef struct _maccel_config_t {
-    float scaling;
     float growth_rate;
     float offset;
     float limit;
     float takeoff;
     bool  enabled;
 } maccel_config_t;
+
+
 /* Timings (in us) used in SPI communication. Since MCU should not do other tasks during wait,
  * k_busy_wait is used instead of k_sleep */
 // - sub-us time is rounded to us, due to the limitation of k_busy_wait, see :

--- a/src/pmw3610.h
+++ b/src/pmw3610.h
@@ -7,6 +7,50 @@
 extern "C" {
 #endif
 
+
+#ifndef MACCEL_CPI
+#    ifdef POINTING_DEVICE_DRIVER_pmw3360
+#        define MACCEL_CPI 120.0
+#    elif POINTING_DEVICE_DRIVER_cirque_pinnacle_spi
+#        define MACCEL_CPI 120.0
+#    else
+#        warning "Unsupported pointing device driver! Please manually set the scaling parameter MACCEL_CPI to achieve a consistent acceleration curve!"
+#        define MACCEL_CPI 120.0
+#    endif
+#endif
+#ifdef MACCEL_SCALE
+#  error "You must rename MACCEL_SCALE as MACCEL_CPI in your `config.h`!"
+#endif // MACCEL_SCALE
+#ifndef MACCEL_TAKEOFF
+// https://www.desmos.com/calculator/vtfkbxwj8s
+#    define MACCEL_TAKEOFF     6.8     // (K) --/++ value --> curve starts smoothlier/abruptlier
+#endif
+#ifndef MACCEL_GROWTH_RATE
+#    define MACCEL_GROWTH_RATE 0.6     // (M) --/++ value --> max limit reached slower/faster
+#endif
+#ifndef MACCEL_OFFSET
+#    define MACCEL_OFFSET      1.0     // (S) --/++ value --> growth kicks in earlier/later
+#endif
+#ifndef MACCEL_LIMIT
+#    define MACCEL_LIMIT       9.6     // (M) maximum acceleration factor
+#endif
+#ifndef MACCEL_CPI_THROTTLE_MS
+#    define MACCEL_CPI_THROTTLE_MS 200 // milliseconds to wait between requesting the device's current DPI
+#endif
+#ifndef MACCEL_ROUNDING_CURRY_TIMEOUT_MS
+#    define MACCEL_ROUNDING_CURRY_TIMEOUT_MS 300 // mouse report delta time after which quantization carry gets reset
+#endif
+
+#define MACCEL_MAGNIFICATION_DPI 1000
+
+typedef struct _maccel_config_t {
+    float scaling;
+    float growth_rate;
+    float offset;
+    float limit;
+    float takeoff;
+    bool  enabled;
+} maccel_config_t;
 /* Timings (in us) used in SPI communication. Since MCU should not do other tasks during wait,
  * k_busy_wait is used instead of k_sleep */
 // - sub-us time is rounded to us, due to the limitation of k_busy_wait, see :


### PR DESCRIPTION
Wymads and Bukfers from bastard keyboards have developed a QMK mouse acceleration. The original version this was based on can be found [here ](https://github.com/finrod09/qmk_userspace_features/tree/main/maccel)

This PR adds the same mouse acceleration to the driver as an optional feature and offers customization for all the formula parameters that are present in the QMK version.

For the parameters for the maccel equation, I had to use int kconfig options and divide them to get the float values.

I have been using this in my keyboard and it has been working as expected, when compared to the wired version